### PR TITLE
feat: endpoint to delete a task image ( #37 )

### DIFF
--- a/src/routes/api/tasks/index.ts
+++ b/src/routes/api/tasks/index.ts
@@ -341,7 +341,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
         return { message: 'File deleted successfully' }
       }).catch((err) => {
         if (err.code === 'ENOENT') {
-          reply.notFound(`File "${filename}" not found`)
+          return reply.notFound(`File "${filename}" not found`)
         }
 
         reply.internalServerError('Transaction failed.')

--- a/src/routes/api/tasks/index.ts
+++ b/src/routes/api/tasks/index.ts
@@ -334,16 +334,20 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
           filename
         )
 
-        await fs.promises.unlink(filePath)
+        await fs.promises.unlink(filePath).catch((err) => {
+          // Just warn if file not found as file deletion 
+          // should be treated as successful if the database operation succeeds,
+          if (err.code === 'ENOENT') {
+            fastify.log.warn(`File path '${filename}' not found`)
+          } else {
+            throw err
+          }
+        })
 
         reply.code(204)
 
         return { message: 'File deleted successfully' }
-      }).catch((err) => {
-        if (err.code === 'ENOENT') {
-          return reply.notFound(`File "${filename}" not found`)
-        }
-
+      }).catch(() => {
         reply.internalServerError('Transaction failed.')
       })
     }

--- a/src/routes/api/tasks/index.ts
+++ b/src/routes/api/tasks/index.ts
@@ -357,7 +357,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
 }
 
 function isErrnoException (error: unknown): error is NodeJS.ErrnoException {
-  return error instanceof Error && 'code' in error;
+  return error instanceof Error && 'code' in error
 }
 
 export default plugin

--- a/src/routes/api/tasks/index.ts
+++ b/src/routes/api/tasks/index.ts
@@ -244,7 +244,6 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
           return reply.badRequest('Invalid file type')
         }
 
-
         const filename = `${id}_${file.filename}`
 
         const affectedRows = await trx<Task>('tasks')
@@ -255,8 +254,6 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
           return reply.notFound('Task not found')
         }
 
-
-
         const filePath = path.join(
           import.meta.dirname,
           '../../../..',
@@ -266,7 +263,6 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
         )
 
         await pipeline(file.file, fs.createWriteStream(filePath))
-
 
         return { message: 'File uploaded successfully' }
       }).catch(() => {
@@ -330,7 +326,6 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
           return reply.notFound(`No task has filename "${filename}"`)
         }
 
-
         const filePath = path.join(
           import.meta.dirname,
           '../../../..',
@@ -340,8 +335,6 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
         )
 
         await fs.promises.unlink(filePath)
-
-
 
         reply.code(204)
 

--- a/src/schemas/tasks.ts
+++ b/src/schemas/tasks.ts
@@ -31,7 +31,7 @@ export const TaskSchema = Type.Object({
 })
 
 export interface Task extends Static<typeof TaskSchema> {
-  filename?: string
+  filename?: string | null
 }
 
 export const CreateTaskSchema = Type.Object({

--- a/test/routes/api/tasks/tasks.test.ts
+++ b/test/routes/api/tasks/tasks.test.ts
@@ -444,7 +444,7 @@ describe('Tasks api (logged user only)', () => {
     })
   })
 
-  describe('Task image upload, retrieval and delete', (context) => {
+  describe('Task image upload, retrieval and delete', () => {
     let app: FastifyInstance
     let taskId: number
     const filename = 'short-logo.png'
@@ -686,12 +686,12 @@ describe('Tasks api (logged user only)', () => {
         app = await build(t)
 
         const taskFilename = encodeURIComponent(`${taskId}_${filename}`)
-        const resDelete = await app.injectWithLogin('basic', {
+        const res = await app.injectWithLogin('basic', {
           method: 'DELETE',
           url: `/api/tasks/${taskFilename}/image`
         })
 
-        assert.strictEqual(resDelete.statusCode, 204)
+        assert.strictEqual(res.statusCode, 204)
 
         const files = fs.readdirSync(uploadDirTask)
         assert.strictEqual(files.length, 0)
@@ -720,13 +720,13 @@ describe('Tasks api (logged user only)', () => {
           filename: 'does_not_exist.png'
         })
 
-        const resDelete = await app.injectWithLogin('basic', {
+        const res = await app.injectWithLogin('basic', {
           method: 'DELETE',
           url: '/api/tasks/does_not_exist.png/image'
         })
 
-        assert.strictEqual(resDelete.statusCode, 404)
-        const { message } = JSON.parse(resDelete.payload)
+        assert.strictEqual(res.statusCode, 404)
+        const { message } = JSON.parse(res.payload)
         assert.strictEqual(message, 'File "does_not_exist.png" not found')
       })
 
@@ -740,12 +740,12 @@ describe('Tasks api (logged user only)', () => {
         const { mock: mockLogError } = t.mock.method(app.log, 'error')
 
         const taskFilename = encodeURIComponent(`${taskId}_${filename}`)
-        const resDelete = await app.injectWithLogin('basic', {
+        const res = await app.injectWithLogin('basic', {
           method: 'DELETE',
           url: `/api/tasks/${taskFilename}/image`
         })
 
-        assert.strictEqual(resDelete.statusCode, 500)
+        assert.strictEqual(res.statusCode, 500)
         assert.strictEqual(mockLogError.callCount(), 1)
 
         const arg = mockLogError.calls[0].arguments[0] as unknown as {

--- a/test/routes/api/tasks/tasks.test.ts
+++ b/test/routes/api/tasks/tasks.test.ts
@@ -710,7 +710,7 @@ describe('Tasks api (logged user only)', () => {
         assert.strictEqual(message, 'No task has filename "non-existant"')
       })
 
-      it('should return 404 for non-existant file in upload dir', async (t) => {
+      it('should return 204 for non-existant file in upload dir', async (t) => {
         const app = await build(t)
 
         await createTask(app, {
@@ -720,14 +720,22 @@ describe('Tasks api (logged user only)', () => {
           filename: 'does_not_exist.png'
         })
 
+        const { mock: mockLogWarn } = t.mock.method(app.log, 'warn')
+
+
+
+
         const res = await app.injectWithLogin('basic', {
           method: 'DELETE',
           url: '/api/tasks/does_not_exist.png/image'
         })
 
-        assert.strictEqual(res.statusCode, 404)
-        const { message } = JSON.parse(res.payload)
-        assert.strictEqual(message, 'File "does_not_exist.png" not found')
+        assert.strictEqual(res.statusCode, 204)
+
+        const arg = mockLogWarn.calls[0].arguments[0]
+        
+        assert.strictEqual(mockLogWarn.callCount(), 1)
+        assert.deepStrictEqual(arg, `File path 'does_not_exist.png' not found`)
       })
 
       it('File deletion transaction should rollback on error', async (t) => {

--- a/test/routes/api/tasks/tasks.test.ts
+++ b/test/routes/api/tasks/tasks.test.ts
@@ -679,14 +679,11 @@ describe('Tasks api (logged user only)', () => {
       })
 
       after(async () => {
-        app = await build()
         const files = fs.readdirSync(uploadDirTask)
         files.forEach((file) => {
           const filePath = path.join(uploadDirTask, file)
           fs.rmSync(filePath, { recursive: true })
         })
-
-        await app.close()
       })
 
       it('should remove an existing image for a task', async (t) => {
@@ -704,7 +701,7 @@ describe('Tasks api (logged user only)', () => {
         assert.strictEqual(files.length, 0)
       })
 
-      it('should return 404 for non-existant filename for deletion', async (t) => {
+      it('should return 404 for non-existant task with filename for deletion', async (t) => {
         app = await build(t)
 
         const res = await app.injectWithLogin('basic', {
@@ -717,11 +714,12 @@ describe('Tasks api (logged user only)', () => {
         assert.strictEqual(message, 'No task has filename "non-existant"')
       })
 
+
       it('File deletion transaction should rollback on error', async (t) => {
         const app = await build(t)
         const { mock: mockPipeline } = t.mock.method(fs.promises, 'unlink')
         mockPipeline.mockImplementationOnce(() => {
-          throw new Error()
+          return Promise.reject(new Error())
         })
 
         const { mock: mockLogError } = t.mock.method(app.log, 'error')

--- a/test/routes/api/tasks/tasks.test.ts
+++ b/test/routes/api/tasks/tasks.test.ts
@@ -722,9 +722,6 @@ describe('Tasks api (logged user only)', () => {
 
         const { mock: mockLogWarn } = t.mock.method(app.log, 'warn')
 
-
-
-
         const res = await app.injectWithLogin('basic', {
           method: 'DELETE',
           url: '/api/tasks/does_not_exist.png/image'
@@ -733,9 +730,9 @@ describe('Tasks api (logged user only)', () => {
         assert.strictEqual(res.statusCode, 204)
 
         const arg = mockLogWarn.calls[0].arguments[0]
-        
+
         assert.strictEqual(mockLogWarn.callCount(), 1)
-        assert.deepStrictEqual(arg, `File path 'does_not_exist.png' not found`)
+        assert.deepStrictEqual(arg, 'File path \'does_not_exist.png\' not found')
       })
 
       it('File deletion transaction should rollback on error', async (t) => {

--- a/test/routes/api/tasks/tasks.test.ts
+++ b/test/routes/api/tasks/tasks.test.ts
@@ -432,7 +432,7 @@ describe('Tasks api (logged user only)', () => {
     })
   })
 
-  describe('Task image upload and retrieval', () => {
+  describe('Task image upload and retrieval and delete', () => {
     let app: FastifyInstance
     let taskId: number
     const filename = 'short-logo.png'
@@ -627,6 +627,34 @@ describe('Tasks api (logged user only)', () => {
 
       const res = await app.injectWithLogin('basic', {
         method: 'GET',
+        url: '/api/tasks/non-existant/image'
+      })
+
+      assert.strictEqual(res.statusCode, 404)
+      const { message } = JSON.parse(res.payload)
+      assert.strictEqual(message, 'No task has filename "non-existant"')
+    })
+
+    it('should remove an existing image for a task', async (t) => {
+      app = await build(t)
+
+      const taskFilename = encodeURIComponent(`${taskId}_${filename}`)
+      const resDelete = await app.injectWithLogin('basic', {
+        method: 'DELETE',
+        url: `/api/tasks/${taskFilename}/image`
+      })
+
+      assert.strictEqual(resDelete.statusCode, 204)
+
+      const files = fs.readdirSync(uploadDirTask)
+      assert.strictEqual(files.length, 0)
+    })
+
+    it('should return 404 for non-existant filename for deletion', async (t) => {
+      app = await build(t)
+
+      const res = await app.injectWithLogin('basic', {
+        method: 'DELETE',
         url: '/api/tasks/non-existant/image'
       })
 


### PR DESCRIPTION
Fixes https://github.com/fastify/demo/issues/37

i had to make filename nullable in Task, because updating it with an undefined raised an internal error

- [x] run `npm run test` and `npm run benchmark`  -- benchmark is not disponible
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
