### PR TITLE
feat: Add SonarQube scan to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,16 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: SonarQube Scan
+        uses: sonarsource/sonarqube-scan-action@v3.0.0
+        with:
+          args: >
+            -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}
+            -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY }}
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
+
       - name: Install dependencies
         run: npm i
 


### PR DESCRIPTION
Fixes #42 

I've added a step in the CI workflow of Github Actions to scan the new code with SonarQube.
Due to the nature of the action, one secret and three variables need to be added to the repository:

Variables: 
- SONAR_ORGANIZATION => the name of the organization 
- SONAR_PROJECT_KEY => the project key
- SONAR_HOST_URL => the SonarCloud URL e.g. https://sonarcloud.io

Secrets:
- SONAR_TOKEN => the API token for SonarCloud

Also the automatic analysis option needs to be disabled as it conflicts with the CI workflows ([documentation](https://docs.sonarsource.com/sonarcloud/advanced-setup/automatic-analysis/#conflict-with-ci-based-analysis)) in the SonarCloud project administration settings in *Administration > Analysis method > Automatic Analysis*

You can check a working execution in this [link](https://github.com/Heyner128/demo-fastify/actions/runs/11540957444)

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
