### PR TITLE
chore: remove tap

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "watch": "tsc -w",
     "dev": "npm run build && concurrently -k -p \"[{name}]\" -n \"TypeScript,App\" -c \"yellow.bold,cyan.bold\" \"npm:watch\" \"npm:dev:start\"",
     "dev:start": "npm run build && fastify start --ignore-watch=.ts$ -w -l info -P dist/app.js",
-    "test": "npm run db:seed && tap --jobs=1 test/**/*",
+    "test": "npm run db:seed && glob -c \"tsx --test\" \"./test/**/*.integration.spec.ts\"",
     "standalone": "npm run build && node --env-file=.env dist/server.js",
     "lint": "eslint --ignore-pattern=dist",
     "lint:fix": "npm run lint -- --fix",
@@ -62,8 +62,8 @@
     "@types/node": "^22.5.5",
     "eslint": "^9.11.0",
     "fastify-tsconfig": "^2.0.0",
+    "glob": "^11.0.0",
     "neostandard": "^0.12.0",
-    "tap": "^21.0.1",
     "tsx": "^4.19.1",
     "typescript": "~5.7.2"
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "watch": "tsc -w",
     "dev": "npm run build && concurrently -k -p \"[{name}]\" -n \"TypeScript,App\" -c \"yellow.bold,cyan.bold\" \"npm:watch\" \"npm:dev:start\"",
     "dev:start": "npm run build && fastify start --ignore-watch=.ts$ -w -l info -P dist/app.js",
-    "test": "npm run db:seed && glob -c \"tsx --test\" \"./test/**/*.integration.spec.ts\"",
+    "test": "npm run db:seed && c8 npm run test:run",
+    "test:run": "glob -c \"tsx --test\" \"./test/**/*.ts\"",
     "standalone": "npm run build && node --env-file=.env dist/server.js",
     "lint": "eslint --ignore-pattern=dist",
     "lint:fix": "npm run lint -- --fix",
@@ -60,6 +61,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.5.5",
+    "c8": "^10.1.3",
     "eslint": "^9.11.0",
     "fastify-tsconfig": "^2.0.0",
     "glob": "^11.0.0",


### PR DESCRIPTION
#### Description

Since all tests are already implemented using node:test, tap is unnecessary for this project (following discussion in fastify/fastify#5555 regarding tap deprecation in fastify projects).

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
