### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/src/plugins/external/static.ts
+++ b/src/plugins/external/static.ts
@@ -1,7 +1,7 @@
 import fastifyStatic, { FastifyStaticOptions } from '@fastify/static'
 import { FastifyInstance } from 'fastify'
-import fs from 'fs'
-import path from 'path'
+import fs from 'node:fs'
+import path from 'node:path'
 
 export const autoConfig = (fastify: FastifyInstance): FastifyStaticOptions => {
   const dirPath = path.join(import.meta.dirname, '../../..', fastify.config.UPLOAD_DIRNAME)

--- a/test/routes/api/tasks/tasks.test.ts
+++ b/test/routes/api/tasks/tasks.test.ts
@@ -12,7 +12,7 @@ import fs from 'node:fs'
 import { pipeline } from 'node:stream/promises'
 import path from 'node:path'
 import FormData from 'form-data'
-import os from 'os'
+import os from 'node:os'
 import { gunzipSync } from 'node:zlib'
 
 async function createUser (


### PR DESCRIPTION
This is a batch PR, so may have some issues. Please review changes.