### PR TITLE
test(routes/api/tasks): limit file permissions

### DIFF
--- a/test/routes/api/tasks/tasks.test.ts
+++ b/test/routes/api/tasks/tasks.test.ts
@@ -629,7 +629,12 @@ describe('Tasks api (logged user only)', () => {
         const largeTestImagePath = path.join(tmpDir, 'large-test-image.jpg')
 
         const largeBuffer = Buffer.alloc(1024 * 1024 * 1.5, 'a') // Max file size in bytes is 1 MB
-        fs.writeFileSync(largeTestImagePath, largeBuffer, { mode: 0o600 }) // 0600 permissions (read/write for owner only)
+        /**
+         * Limit file permissions to read/write for the owner only by setting mode
+         * to 0600, as permissions should follow the principle of least privilege.
+         * @see {@link https://learn.snyk.io/lesson/insecure-temporary-file/?ecosystem=javascript | Insecure temporary file}
+         */
+        fs.writeFileSync(largeTestImagePath, largeBuffer, { mode: 0o600 })
 
         const form = new FormData()
         form.append('file', fs.createReadStream(largeTestImagePath))

--- a/test/routes/api/tasks/tasks.test.ts
+++ b/test/routes/api/tasks/tasks.test.ts
@@ -629,7 +629,7 @@ describe('Tasks api (logged user only)', () => {
         const largeTestImagePath = path.join(tmpDir, 'large-test-image.jpg')
 
         const largeBuffer = Buffer.alloc(1024 * 1024 * 1.5, 'a') // Max file size in bytes is 1 MB
-        fs.writeFileSync(largeTestImagePath, largeBuffer)
+        fs.writeFileSync(largeTestImagePath, largeBuffer, { mode: 0o600 }) // 0600 permissions (read/write for owner only)
 
         const form = new FormData()
         form.append('file', fs.createReadStream(largeTestImagePath))


### PR DESCRIPTION
Closes https://github.com/fastify/demo/security/code-scanning/2

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
