### PR TITLE
ci: set workflow permissions to read-only by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ on:
       - "docs/**"
       - "*.md"
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     permissions:


### PR DESCRIPTION
This PR is created by a script. Please check the changes prior to merging.

This PR adds permissions to the workflow and job level, making the workflows read-only by default, and allowing write access only at the job level via granular permissions. This is regularly flagged by CodeQL, Step Security, [OSSF](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions), and other security tools.
This change also allows the org to go read-only everywhere, see https://github.com/fastify/avvio/pull/308#issuecomment-2765300174