### PR TITLE
fix: update-password response status type error

### DIFF
--- a/src/routes/api/users/index.ts
+++ b/src/routes/api/users/index.ts
@@ -21,6 +21,9 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
           200: Type.Object({
             message: Type.String()
           }),
+          400: Type.Object({
+            message: Type.String()
+          }),
           401: Type.Object({
             message: Type.String()
           })


### PR DESCRIPTION
a small type error fix:
```
➜  fastify-demo git:(main) npm run dev                                                    

> fastify-demo@0.0.0 dev
> npm run build && concurrently -k -p "[{name}]" -n "TypeScript,App" -c "yellow.bold,cyan.bold" "npm:watch" "npm:dev:start"


> fastify-demo@0.0.0 build
> tsc

src/routes/api/users/index.ts:51:22 - error TS2345: Argument of type '400' is not assignable to parameter of type '200 | 401'.

51         reply.status(400)
                        ~~~


Found 1 error in src/routes/api/users/index.ts:51
```