### PR TITLE
Docs: add env setup before db commands

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,6 @@ FASTIFY_CLOSE_GRACE_DELAY=1000
 LOG_LEVEL=info
 
 # Security
-COOKIE_SECRET=0123456789abcdef0123456789abcdef
+COOKIE_SECRET=
 COOKIE_NAME=session_id
 RATE_LIMIT_MAX=4 # 4 is for tests, increase if you need more

--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,6 @@ FASTIFY_CLOSE_GRACE_DELAY=1000
 LOG_LEVEL=info
 
 # Security
-COOKIE_SECRET=
-COOKIE_NAME=
+COOKIE_SECRET=0123456789abcdef0123456789abcdef
+COOKIE_NAME=session_id
 RATE_LIMIT_MAX=4 # 4 is for tests, increase if you need more

--- a/README.md
+++ b/README.md
@@ -18,12 +18,16 @@ Install the dependencies:
 npm install
 ```
 
-### Database
+### Environment variables
 
-Prepare the environment file:
+Create a `.env` file based on `.env.example` and update values as needed.
+
+Make sure `COOKIE_SECRET` is set to a 32-byte secret (64 hex chars) in your `.env`. You can generate a random secret with:
 ```bash
-cp .env.example .env
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 ```
+
+### Database
 
 Run MySQL with Docker:
 ```bash

--- a/README.md
+++ b/README.md
@@ -22,14 +22,11 @@ npm install
 
 Create a `.env` file based on `.env.example` and update values as needed.
 
-Make sure `COOKIE_SECRET` is set to a 32-byte secret (64 hex chars) in your `.env`. You can generate a random secret with:
-```bash
-node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
-```
+Make sure `COOKIE_SECRET` is set to a secret with at least 32 characters.
 
 ### Database
 
-Run MySQL with Docker:
+You can run a MySQL instance with Docker:
 ```bash
 docker compose up
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,13 @@ npm install
 ```
 
 ### Database
-You can run a MySQL instance with Docker:
+
+Prepare the environment file:
+```bash
+cp .env.example .env
+```
+
+Run MySQL with Docker:
 ```bash
 docker compose up
 ```


### PR DESCRIPTION
Fixes #132 document copying `.env.example` to `.env` before running db scripts