### PR TITLE
Feat: Handle HTTP timeouts

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -38,6 +38,13 @@ function getLoggerOptions () {
 
 const app = Fastify({
   logger: getLoggerOptions(),
+  // Apply recommended timeouts to prevent slow or idle clients from holding connections open
+  connectionTimeout: 120_000,
+  requestTimeout: 60_000,
+  keepAliveTimeout: 10_000,
+  http: {
+    headersTimeout: 15_000
+  },
   ajv: {
     customOptions: {
       coerceTypes: 'array', // change type of data to match type keyword


### PR DESCRIPTION
## Summary
- apply recommended Fastify HTTP timeouts to the demo server

Closes fastify/demo#94

Reference: https://backend.cafe/handling-http-timeouts-in-fastify