### PR TITLE
Increased RATE_LIMIT_MAX in .env.example to 10 to allow for docs page to open

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,4 +20,4 @@ LOG_LEVEL=info
 # Security
 COOKIE_SECRET=
 COOKIE_NAME=session_id
-RATE_LIMIT_MAX=4 # 4 is for tests, increase if you need more
+RATE_LIMIT_MAX=10 # 4 is for tests, increase if you need more

--- a/.env.example
+++ b/.env.example
@@ -20,4 +20,4 @@ LOG_LEVEL=info
 # Security
 COOKIE_SECRET=
 COOKIE_NAME=session_id
-RATE_LIMIT_MAX=10 # 4 is for tests, increase if you need more
+RATE_LIMIT_MAX=10 # 10 is for tests, increase if you need more


### PR DESCRIPTION
With RATE_LIMIT_MAX set to 4 swagger docs page is unable to load
