### PR TITLE
chore: update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ yarn.lock
 
 # uploaded files
 uploads/tasks/*
+
+# macOS files
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "db:migrate": "tsx --env-file=.env ./scripts/migrate.ts",
     "db:seed": "tsx --env-file=.env ./scripts/seed-database.ts"
   },
-  "keywords": [],
+  "keywords": [
+    "fastify",
+    "demo"
+  ],
   "author": "Michelet Jean <jean.antoine.michelet@gmail.com>",
   "license": "MIT",
   "repository": {
@@ -35,39 +38,39 @@
   "dependencies": {
     "@fastify/autoload": "^6.3.1",
     "@fastify/cookie": "^11.0.2",
-    "@fastify/cors": "^11.1.0",
-    "@fastify/env": "^5.0.2",
-    "@fastify/helmet": "^13.0.1",
-    "@fastify/multipart": "^9.2.1",
+    "@fastify/cors": "^11.2.0",
+    "@fastify/env": "^5.0.3",
+    "@fastify/helmet": "^13.0.2",
+    "@fastify/multipart": "^9.4.0",
     "@fastify/rate-limit": "^10.3.0",
-    "@fastify/sensible": "^6.0.3",
-    "@fastify/session": "^11.1.0",
+    "@fastify/sensible": "^6.0.4",
+    "@fastify/session": "^11.1.1",
     "@fastify/static": "^9.0.0",
-    "@fastify/swagger": "^9.5.1",
-    "@fastify/swagger-ui": "^5.2.3",
-    "@fastify/type-provider-typebox": "^5.2.0",
+    "@fastify/swagger": "^9.7.0",
+    "@fastify/swagger-ui": "^5.2.5",
+    "@fastify/type-provider-typebox": "^6.1.0",
     "@fastify/under-pressure": "^9.0.3",
-    "@sinclair/typebox": "^0.34.41",
-    "close-with-grace": "^2.2.0",
-    "concurrently": "^9.2.1",
+    "close-with-grace": "^2.5.0",
     "csv-stringify": "^6.6.0",
-    "fastify": "^5.6.0",
-    "fastify-plugin": "^5.0.1",
-    "knex": "^3.1.0",
-    "mysql2": "^3.15.0",
+    "fastify": "^5.8.4",
+    "fastify-plugin": "^5.1.0",
+    "knex": "^3.2.6",
+    "mysql2": "^3.20.0",
     "postgrator": "^8.0.0",
-    "sanitize-filename": "^1.6.3"
+    "sanitize-filename": "^1.6.3",
+    "typebox": "^1.1.6"
   },
   "devDependencies": {
     "@types/node": "^25.0.3",
     "c8": "^11.0.0",
-    "eslint": "^9.35.0",
+    "concurrently": "^9.2.1",
+    "eslint": "^9.39.0",
     "fastify-tsconfig": "^3.0.0",
-    "form-data": "^4.0.4",
+    "form-data": "^4.0.5",
     "glob": "^11.0.3",
     "neostandard": "^0.13.0",
-    "pino-pretty": "^13.1.2",
-    "tsx": "^4.20.5",
-    "typescript": "~5.9.2"
+    "pino-pretty": "^13.1.3",
+    "tsx": "^4.21.0",
+    "typescript": "~6.0.2"
   }
 }

--- a/src/plugins/app/file-manager.ts
+++ b/src/plugins/app/file-manager.ts
@@ -1,4 +1,4 @@
-import { ReturnType } from '@sinclair/typebox'
+import { ReturnType } from 'typebox'
 import { FastifyInstance } from 'fastify'
 import fp from 'fastify-plugin'
 import fs from 'fs'

--- a/src/plugins/app/tasks/tasks-file-manager.ts
+++ b/src/plugins/app/tasks/tasks-file-manager.ts
@@ -1,4 +1,4 @@
-import { ReturnType } from '@sinclair/typebox'
+import { ReturnType } from 'typebox'
 import { FastifyInstance } from 'fastify'
 import fp from 'fastify-plugin'
 import path from 'path'

--- a/src/plugins/app/tasks/tasks-repository.ts
+++ b/src/plugins/app/tasks/tasks-repository.ts
@@ -1,4 +1,4 @@
-import { ReturnType, Static } from '@sinclair/typebox'
+import { ReturnType, Static } from 'typebox'
 import { FastifyInstance } from 'fastify'
 import fp from 'fastify-plugin'
 import {

--- a/src/routes/api/tasks/index.ts
+++ b/src/routes/api/tasks/index.ts
@@ -309,7 +309,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
     {
       schema: {
         response: {
-          200: { type: 'string', contentMediaType: 'application/gzip' },
+          200: Type.Unknown({ type: 'string', contentMediaType: 'application/gzip' }),
           400: Type.Object({ message: Type.String() })
         },
         tags: ['Tasks']

--- a/src/schemas/auth.ts
+++ b/src/schemas/auth.ts
@@ -1,4 +1,4 @@
-import { Static, Type } from '@sinclair/typebox'
+import { Static, Type } from 'typebox'
 import { EmailSchema, StringSchema } from './common.js'
 
 export const CredentialsSchema = Type.Object({

--- a/src/schemas/common.ts
+++ b/src/schemas/common.ts
@@ -1,4 +1,4 @@
-import { Type } from '@sinclair/typebox'
+import { Type } from 'typebox'
 
 export const StringSchema = Type.String({
   minLength: 1,

--- a/src/schemas/tasks.ts
+++ b/src/schemas/tasks.ts
@@ -1,4 +1,4 @@
-import { Static, Type } from '@sinclair/typebox'
+import { Static, Type } from 'typebox'
 import { DateTimeSchema, IdSchema, StringSchema } from './common.js'
 
 export const TaskStatusEnum = {

--- a/src/schemas/users.ts
+++ b/src/schemas/users.ts
@@ -1,4 +1,4 @@
-import { Type } from '@sinclair/typebox'
+import { Type } from 'typebox'
 
 const passwordPattern = '^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).*$'
 

--- a/test/routes/api/tasks/tasks.test.ts
+++ b/test/routes/api/tasks/tasks.test.ts
@@ -7,7 +7,7 @@ import {
   TaskPaginationResultSchema
 } from '../../../../src/schemas/tasks.js'
 import { FastifyInstance } from 'fastify'
-import { Static } from '@sinclair/typebox'
+import { Static } from 'typebox'
 import fs from 'node:fs'
 import { pipeline } from 'node:stream/promises'
 import path from 'node:path'


### PR DESCRIPTION
Proposal:

Update dependencies to their latest stable versions:

- `@fastify/cors`: `^11.1.0` → `^11.2.0`
- `@fastify/env`: `^5.0.2` → `^5.0.3`
- `@fastify/helmet`: `^13.0.1` → `^13.0.2`
- `@fastify/multipart`: `^9.2.1` → `^9.4.0`
- `@fastify/sensible`: `^6.0.3` → `^6.0.4`
- `@fastify/session`: `^11.1.0` → `^11.1.1`
- `@fastify/swagger`: `^9.5.1` → `^9.7.0`
- `@fastify/swagger-ui`: `^5.2.3` → `^5.2.5`
- `@fastify/type-provider-typebox`: `^5.2.0` → `^6.1.0`
- `close-with-grace`: `^2.2.0` → `^2.5.0`
- `fastify`: `^5.6.0` → `^5.8.4`
- `fastify-plugin`: `^5.0.1` → `^5.1.0`
- `knex`: `^3.1.0` → `^3.2.6`
- `mysql2`: `^3.15.0` → `^3.20.0`
- `typebox`: `^1.1.6`
- `eslint`: `^9.35.0` → `^9.39.0`
- `form-data`: `^4.0.4` → `^4.0.5`
- `pino-pretty`: `^13.1.2` → `^13.1.3`
- `tsx`: `^4.20.5` → `^4.21.0`
- `typescript`: `~5.9.2` → `~6.0.2`

Note: 

- Replaced `@sinclair/typebox` package with  `typebox` package, see documentation here: https://fastify.dev/docs/latest/Reference/Type-Providers/#typebox
- Update `.gitignore` added `.DS_Store`

- This PR should close this PR: https://github.com/fastify/demo/pull/128 

See Reference PR: https://github.com/fastify/fastify/pull/6605