### PR TITLE
chore: update @fastify/env dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@fastify/autoload": "^6.3.1",
     "@fastify/cookie": "^11.0.2",
     "@fastify/cors": "^11.2.0",
-    "@fastify/env": "^5.0.3",
+    "@fastify/env": "^6.0.0",
     "@fastify/helmet": "^13.0.2",
     "@fastify/multipart": "^9.4.0",
     "@fastify/rate-limit": "^10.3.0",


### PR DESCRIPTION
Proposal:

- update `@fastify/env` dependency to `v6.0.0`, because the `v5.0.3` it still uses `dotenv` internally