### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,4 +105,4 @@ npm run lint:fix
 ```
 
 ## Learn More
-To learn more about Fastify, check out the [Fastify documentation](https://www.fastify.io/docs/latest/).
+To learn more about Fastify, check out the [Fastify documentation](https://fastify.dev/docs/latest/).


### PR DESCRIPTION
Fixes 404s, 3xx redirections, and missing fragments in the documentation. Part of general link cleanup being tracked in https://github.com/fastify/accept-negotiator/pull/71